### PR TITLE
wxversion in startup files of swapdmt and swapmaker

### DIFF
--- a/swapdmt/SwapManager.py
+++ b/swapdmt/SwapManager.py
@@ -26,6 +26,9 @@ __author__="Daniel Berenguer"
 __date__ ="$Aug 21, 2011 4:30:47 PM$"
 #########################################################################
 
+import wxversion
+wxversion.select('2.8')
+
 from swap.SwapInterface import SwapInterface
 from swap.protocol.SwapDefs import SwapState
 from swap.SwapException import SwapException

--- a/swapmaker/swapmaker.py
+++ b/swapmaker/swapmaker.py
@@ -25,6 +25,9 @@ __author__="Daniel Berenguer"
 __date__ ="$Apr 23, 2012"
 #########################################################################
 
+import wxversion
+wxversion.select('2.8')
+
 from wizard import SwapWizard
 from errors import SwapMakerException
 


### PR DESCRIPTION
WX seems to be backwards incompatible (at least from 3.0), however, multiple versions are easily installable on one system. This allows selection of 2.8 at runtime.
