### PR TITLE
fixes endpointpanel if firmware server is in the network

### DIFF
--- a/lagarto/lagarto-swap/swapmanager.py
+++ b/lagarto/lagarto-swap/swapmanager.py
@@ -148,9 +148,10 @@ class SwapManager(SwapInterface, LagartoProcess):
         status = []
         if endpoints is None:
             for mote in self.network.motes:
-                for reg in mote.regular_registers:
-                    for endp in reg.parameters:
-                        status.append(endp.dumps())
+                if mote.regular_registers:
+                    for reg in mote.regular_registers:
+                        for endp in reg.parameters:
+                            status.append(endp.dumps())
         else:
             for item in endpoints:
                 if "id" not in item:


### PR DESCRIPTION
If "Firmware server" mote is present on the network (and the lagarto process discovers it) it crashes the endpoint panel, because "Firmware server" does not have "regular registers" (line 152, None cannot be iterated over). 
With this fix a check is done if the mote has regular registers - if yes, they are iterated over.